### PR TITLE
add Custom SSL Port support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ Azure has a slightly different way of signaling encrypted connections. To tell e
 
 Please do *not* set this flag if you are not behind an Azure proxy as this flag can easily be spoofed outside of an Azure environment.
 
+### Custom SSL Port
+
+Specify on which SSL port should connections be redirected by setting `port` in options.
+
+`app.use(enforce.HTTPS({ port: 3001 }))`
+
+This will redirect requests for example from `http://foo.bar:3000/baz` to `https://foo.bar:3001/baz`.
+
 
 ## Tests
 Download the whole repository and call:

--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 "use strict";
 
+var url = require('url');
+
 var defaults = {
+	port: null,
 	trustProtoHeader: false,
 	trustAzureHeader: false
 };
@@ -26,6 +29,7 @@ function applyOptions(options) {
  * enforceHTTPS
  *
  * @param {Hash} options
+ * @param {Number} options[port]
  * @param {Boolean} options[trustProtoHeader]
  * @param {Boolean} options[trustAzureHeader]
  * @api public
@@ -59,7 +63,16 @@ var enforceHTTPS = function(options) {
 		} else {
 			// Only redirect GET methods
 			if(req.method === "GET" || req.method === 'HEAD') {
-				res.redirect(301, "https://" + req.headers.host + req.originalUrl);
+				var hostname = url.parse('http://' + req.headers.host).hostname;
+
+				var redirectUrl
+				if (options.port != null) {
+					redirectUrl = "https://" + hostname + ':' + options.port + req.url
+				} else {
+					redirectUrl = "https://" + hostname + req.url;
+				}
+
+				res.redirect(301, redirectUrl);
 			} else {
 				res.status(403).send("Please use HTTPS when submitting data to this server.");
 			}

--- a/test/express-sslify.test.js
+++ b/test/express-sslify.test.js
@@ -202,6 +202,20 @@ describe('express-sslify', function() {
 		proxyTests('head');
 	})
 
+	describe('Custom SSL Port', function () {
+
+		it('should redirect to specified port', function (done) {
+			var app = express();
+
+			app.use(enforce.HTTPS({ port: 3001 }));
+
+			request.agent(app)
+				.get('/ssl')
+				.expect(301)
+				.expect('location', new RegExp('^https://[\\S]*\:3001/ssl$'), done);
+		});
+	});
+
 	describe('Pre-1.0.0-style arguments', function() {
 
 		var app = express();


### PR DESCRIPTION
Fixes #11

Adopted  from [turboMaCk/koa-sslify](https://github.com/turboMaCk/koa-sslify):
- [Test](https://github.com/turboMaCk/koa-sslify/blob/315fa244832df292dd0a90cb999544d5a691f5db/test/koa-sslify-test.js#L83-L91)
- [Code](https://github.com/turboMaCk/koa-sslify/blob/315fa244832df292dd0a90cb999544d5a691f5db/index.js#L105-L106)

For backward compatibility port is null so i have not adopted first test from here koa-sslify.
