### PR TITLE
support x-forwarded-proto header with multiple proxies

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ var enforceHTTPS = function(options) {
 		// Second, if the request headers can be trusted (e.g. because they are send
 		// by a proxy), check if x-forward-proto is set to https
 		if(!isHttps && options.trustProtoHeader) {
-			isHttps = (req.headers["x-forwarded-proto"] === "https");
+			isHttps = ((req.headers["x-forwarded-proto"] || '').match(/^https,?/));
 		}
 
 		// Third, if trustAzureHeader is set, check for Azure's headers

--- a/test/express-sslify.test.js
+++ b/test/express-sslify.test.js
@@ -123,6 +123,13 @@ describe('express-sslify', function() {
 					.expect(200, done);
 			})
 
+			it('should accept request if flag set and activated (' + method.toUpperCase() + ') with comma separated list', function (done) {
+				agent
+					[method]('/ssl-behind-proxy')
+					.set('x-forwarded-proto', 'https, http')
+					.expect(200, done);
+			})
+
 			it('should redirect if activated but flag not set (' + method.toUpperCase() + ')', function (done) {
 				agent
 					[method]('/ssl-behind-proxy')
@@ -176,6 +183,13 @@ describe('express-sslify', function() {
 				agent
 					[method]('/ssl-behind-azure')
 	      			.set('x-arr-ssl', 'https')
+					.expect(200, done);
+			})
+
+			it('should accept request if flag set and activated (' + method.toUpperCase() + ') with a comma separated list', function (done) {
+				agent
+					[method]('/ssl-behind-azure')
+					.set('x-arr-ssl', 'https, http')
 					.expect(200, done);
 			})
 


### PR DESCRIPTION
It is possible under certain conditions when multiple load balancers are in play the x-forwarded-proto header should expect that https is forwards as long as the first entry in a comma separated list for x-forwarded-proto is https.

I changed the check for trusting the proto header to use a regular expression matching what other libraries are doing.