### PR TITLE
use x-forwarded-host header value as hostname for redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Azure has a slightly different way of signaling encrypted connections. To tell e
 
 Please do *not* set this flag if you are not behind an Azure proxy as this flag can be easily spoofed outside of an Azure environment.
 
+### X-Forwarded-Host header support
+
+If your reverse proxy sends the original host using the `X-Forwarded-Host` header and you need to use that instead of the `Host` header for the redirect, use the `trustXForwardedHostHeader` flag:
+
+`app.use(enforce.HTTPS({ trustXForwardedHostHeader: true }))`
 
 ## Tests
 Download the whole repository and call:

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
 
 var defaults = {
 	trustProtoHeader: false,
-	trustAzureHeader: false
+	trustAzureHeader: false,
+	trustXForwardedHostHeader: false
 };
 
 /**
@@ -59,7 +60,7 @@ var enforceHTTPS = function(options) {
 		} else {
 			// Only redirect GET methods
 			if(req.method === "GET" || req.method === 'HEAD') {
-				var host = req.headers['x-forwarded-host'] || req.headers.host;
+				var host = options.trustXForwardedHostHeader ? (req.headers['x-forwarded-host'] || req.headers.host) : req.headers.host;
 				res.redirect(301, "https://" + host + req.originalUrl);
 			} else {
 				res.status(403).send("Please use HTTPS when submitting data to this server.");

--- a/index.js
+++ b/index.js
@@ -59,7 +59,8 @@ var enforceHTTPS = function(options) {
 		} else {
 			// Only redirect GET methods
 			if(req.method === "GET" || req.method === 'HEAD') {
-				res.redirect(301, "https://" + req.headers.host + req.originalUrl);
+				var host = req.headers['x-forwarded-host'] || req.headers.host;
+				res.redirect(301, "https://" + host + req.originalUrl);
 			} else {
 				res.status(403).send("Please use HTTPS when submitting data to this server.");
 			}


### PR DESCRIPTION
I'm proxying requests to node from Apache, and the proxy points to `localhost:8888`. When a redirect happens, the browser was sent to `localhost:8888` instead of the public-facing hostname. This pull request makes the redirect hostname attempt to use the value from the `x-forwarded-host` header, falling back to `req.headers.host` if `x-forwarded-host` isn't available.